### PR TITLE
Use namespace from the request rather than the pod

### DIFF
--- a/webhook/credentials.go
+++ b/webhook/credentials.go
@@ -73,7 +73,7 @@ func (w *CredentialsInjector) Handle(ctx context.Context, req admission.Request)
 		return admission.Denied(message)
 	}
 
-	serviceAccount, err := w.getServiceAccount(ctx, pod)
+	serviceAccount, err := w.getServiceAccount(ctx, pod.Spec.ServiceAccountName, req.Namespace)
 	if k8serrors.IsNotFound(err) {
 		message := "Pod ServiceAccount does not exist"
 		logger.Error(err, message)
@@ -104,11 +104,11 @@ func (w *CredentialsInjector) Handle(ctx context.Context, req admission.Request)
 	return getPatchedResponse(req, mutatedPod)
 }
 
-func (w *CredentialsInjector) getServiceAccount(ctx context.Context, pod *corev1.Pod) (*corev1.ServiceAccount, error) {
+func (w *CredentialsInjector) getServiceAccount(ctx context.Context, name, namespace string) (*corev1.ServiceAccount, error) {
 	serviceAccount := &corev1.ServiceAccount{}
 	namespacedName := types.NamespacedName{
-		Name:      pod.Spec.ServiceAccountName,
-		Namespace: pod.Namespace,
+		Name:      name,
+		Namespace: namespace,
 	}
 
 	err := w.client.Get(ctx, namespacedName, serviceAccount)

--- a/webhook/credentials_test.go
+++ b/webhook/credentials_test.go
@@ -50,8 +50,7 @@ var _ = Describe("Credentials", func() {
 
 		pod = corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "the-pod",
-				Namespace: namespace,
+				Name: "the-pod",
 				Labels: map[string]string{
 					webhook.LabelWorkloadIdentity: "enabled",
 				},
@@ -81,6 +80,7 @@ var _ = Describe("Credentials", func() {
 			AdmissionRequest: admissionv1.AdmissionRequest{
 				Object:    encodeObject(pod),
 				Operation: admissionv1.Create,
+				Namespace: namespace,
 			},
 		}
 	})


### PR DESCRIPTION
For literal Pod resources the previous was fine. However Pods created by
a ReplicaSet for example do not actually have the Namespace in their
definition. Or at least they don't at the time the webhook is called.