### PR TITLE
Do not get service account when mutating pod

### DIFF
--- a/webhook/credentials.go
+++ b/webhook/credentials.go
@@ -10,8 +10,6 @@ import (
 	"github.com/go-logr/logr"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -71,18 +69,6 @@ func (w *CredentialsInjector) Handle(ctx context.Context, req admission.Request)
 		return admission.Denied(message)
 	}
 
-	_, err = w.getServiceAccount(ctx, pod)
-	if k8serrors.IsNotFound(err) {
-		message := "Pod ServiceAccount does not exist"
-		logger.Error(err, message)
-		return admission.Denied(message)
-	}
-
-	if err != nil {
-		logger.Error(err, "failed to get membership from secret")
-		return admission.Errored(http.StatusInternalServerError, err)
-	}
-
 	secretName := fmt.Sprintf("%s-%s", pod.Spec.ServiceAccountName, "google-application-credentials")
 	membership, err := controllers.GetMembershipFromSecret(ctx, w.client, logger)
 	if err != nil {
@@ -102,21 +88,6 @@ func (w *CredentialsInjector) Handle(ctx context.Context, req admission.Request)
 	}
 
 	return getPatchedResponse(req, mutatedPod)
-}
-
-func (w *CredentialsInjector) getServiceAccount(ctx context.Context, pod *corev1.Pod) (*corev1.ServiceAccount, error) {
-	serviceAccount := &corev1.ServiceAccount{}
-	namespacedName := types.NamespacedName{
-		Name:      pod.Spec.ServiceAccountName,
-		Namespace: pod.Namespace,
-	}
-
-	err := w.client.Get(ctx, namespacedName, serviceAccount)
-	if err != nil {
-		return nil, err
-	}
-
-	return serviceAccount, nil
 }
 
 func (w *CredentialsInjector) getLogger(ctx context.Context) logr.Logger {

--- a/webhook/credentials_test.go
+++ b/webhook/credentials_test.go
@@ -28,11 +28,10 @@ var _ = Describe("Credentials", func() {
 		ctx                context.Context
 		credentialsWebhook *webhook.CredentialsInjector
 
-		pod            corev1.Pod
-		serviceAccount *corev1.ServiceAccount
-		gcpCluster     *infra.GCPCluster
-		request        admission.Request
-		response       admission.Response
+		pod        corev1.Pod
+		gcpCluster *infra.GCPCluster
+		request    admission.Request
+		response   admission.Response
 
 		gcpProject           = "testing-1234"
 		workloadIdentityPool = fmt.Sprintf("%s.svc.id.goog", gcpProject)
@@ -44,17 +43,6 @@ var _ = Describe("Credentials", func() {
 		decoder, err := admission.NewDecoder(runtime.NewScheme())
 		Expect(err).NotTo(HaveOccurred())
 		credentialsWebhook = webhook.NewCredentialsInjector(k8sClient, decoder)
-
-		serviceAccount = &corev1.ServiceAccount{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "the-service-account",
-				Namespace: namespace,
-				Annotations: map[string]string{
-					controllers.AnnotationGCPServiceAccount: "service-account@email",
-				},
-			},
-		}
-		Expect(k8sClient.Create(ctx, serviceAccount)).To(Succeed())
 
 		pod = corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -242,19 +230,6 @@ var _ = Describe("Credentials", func() {
 		})
 
 		It("denies the request", func() {
-			Expect(response.AdmissionResponse.Allowed).To(BeFalse())
-			Expect(response.Result).NotTo(BeNil())
-			Expect(response.Result.Code).To(Equal(int32(http.StatusForbidden)))
-		})
-	})
-
-	When("the service account doesn't exist", func() {
-		BeforeEach(func() {
-			pod.Spec.ServiceAccountName = "does-not-exist"
-			request.Object = encodeObject(pod)
-		})
-
-		It("returns a 400 Bad Request", func() {
 			Expect(response.AdmissionResponse.Allowed).To(BeFalse())
 			Expect(response.Result).NotTo(BeNil())
 			Expect(response.Result.Code).To(Equal(int32(http.StatusForbidden)))


### PR DESCRIPTION
If the Pod's ServiceAccount doesn't have the annotation the reconciler won't create the Secret. By removing this check the Pod will remain Pending instead of not being created at all.